### PR TITLE
Replace Set with polyfill

### DIFF
--- a/src/integrations/Integration.js
+++ b/src/integrations/Integration.js
@@ -1,11 +1,12 @@
 // @flow
+import {SimpleSet} from '../utilities'
 export type VideoId = string
 
 class Integration {
   __ids: Set<string>
 
   constructor() {
-    this.__ids = new Set()
+    this.__ids = new SimpleSet()
   }
 
   // Actions
@@ -20,7 +21,7 @@ class Integration {
   }
 
   getIds(): Object {
-    return this.__ids
+    return this.__ids.getItems()
   }
 
   /* istanbul ignore next */

--- a/src/integrations/__tests__/Integration.test.js
+++ b/src/integrations/__tests__/Integration.test.js
@@ -9,6 +9,17 @@ describe('Integration', () => {
       expect(o.getIds()).toContain('123')
     })
 
+    test('Does not add duplicate IDs', () => {
+      const o = new Integration()
+      o.add('123')
+      o.add('123')
+      o.add('123')
+      o.add('123')
+      o.add('123')
+
+      expect(o.getIds().length).toBe(1)
+    })
+
     test('Fires callback on add', () => {
       const spy = jest.fn()
       const o = new Integration()
@@ -23,9 +34,29 @@ describe('Integration', () => {
     test('Removes id from ids', () => {
       const o = new Integration()
       o.add('123')
+      o.add('456')
       o.remove('123')
 
       expect(o.getIds()).not.toContain('123')
+      expect(o.getIds()).toContain('456')
+    })
+
+    test('Cannot remove ID that does not exist', () => {
+      const o = new Integration()
+      o.add('123')
+      o.add('456')
+      o.remove('123')
+      o.remove('123')
+      o.remove('123')
+      o.remove('123')
+      o.remove('123')
+
+      expect(o.getIds()).not.toContain('123')
+      expect(o.getIds()).toContain('456')
+
+      expect(o.getIds().length).toBe(1)
+      o.remove('456')
+      expect(o.getIds().length).toBe(0)
     })
 
     test('Fires callback on remove', () => {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -9,3 +9,25 @@ export const contains = (string: string, match: string): boolean => {
 }
 
 export const getDocumentFromReactComponent = getDocumentFromComponent
+
+// Simple Set polyfill.
+export class SimpleSet {
+  constructor() {
+    this.items = []
+  }
+
+  add(item) {
+    if (this.items.indexOf(item) >= 0) return
+    this.items.push(item)
+  }
+
+  delete(item) {
+    const index = this.items.indexOf(item)
+    if (this.items.indexOf(item) < 0) return
+    this.items.splice(index, 1)
+  }
+
+  getItems() {
+    return this.items
+  }
+}


### PR DESCRIPTION
## Replace Set with polyfill

This update replaces the (native) Set object with a dumb-down polyfill.
This is to get around support for older browsers and without relying on
Babel's runtime polyfill.